### PR TITLE
Accumulate global stats automatically along with hourly stats

### DIFF
--- a/lib/stats.js
+++ b/lib/stats.js
@@ -3,12 +3,13 @@
 
 'use strict';
 
-const { oidFromDateTime, currentHour } = require('./oid');
+const { currentHour, objectIdTimeZero, oidFromDateTime } = require('./oid');
 const utils = require('./utils');
 
 // Accumulators
 let arrayStats = {};
 let counterStats = {};
+let globalCounterStats = {};
 
 const DEFAULT_PERIOD = 5 * 60 * 1000;
 
@@ -38,16 +39,29 @@ function flushStats() {
   log.debug('flushStats: Updating stats');
 
   const ops = {};
+  const globalOps = {};
+  let haveOps = false;
+  let haveGlobalOps = false;
+
   if (!utils.isEmpty(arrayStats)) {
+    haveOps = true;
     ops.$addToSet = arrayStats;
     arrayStats = {};
     log.debug(`flushStats: Updating ${ops.$addToSet.length} array-based stats`);
   }
 
   if (!utils.isEmpty(counterStats)) {
+    haveOps = true;
     ops.$inc = counterStats;
     counterStats = {};
     log.debug(`updateStats: Updating ${ops.$inc.length} increment-based stats`);
+  }
+
+  if (!utils.isEmpty(globalCounterStats)) {
+    haveGlobalOps = true;
+    globalOps.$inc = globalCounterStats;
+    globalCounterStats = {};
+    log.debug(`updateStats: Updating ${globalOps.$inc.length} increment-based global stats`);
   }
 
   if (!Stats) {
@@ -55,11 +69,28 @@ function flushStats() {
     return;
   }
 
-  Stats.update(
-    { _id: oidFromDateTime(currentHour()) },
-    ops,
-    { upsert: true, setDefaultsOnInsert: true }
-  ).exec()
+  const promises = [];
+  if (haveOps) {
+    promises.push(Stats.update(
+      { _id: oidFromDateTime(currentHour()) },
+      ops,
+      { upsert: true, setDefaultsOnInsert: true }
+    ).exec());
+  }
+
+  if (haveGlobalOps) {
+    promises.push(Stats.update(
+      { _id: objectIdTimeZero },
+      globalOps,
+      { upsert: true, setDefaultsOnInsert: true }
+    ).exec());
+  }
+
+  if (promises.length === 0) {
+    return;
+  }
+
+  Promise.allSettled(promises)
     .then(() => {
       log.debug('updateStats: Stats update succeeded');
       return null;
@@ -95,6 +126,12 @@ function stats(key, val_) {
     } else {
       arrayStats[key].$each.push(val);
     }
+
+    if (!(key in globalCounterStats)) {
+      counterStats[key] = 1;
+    } else {
+      counterStats[key] += 1;
+    }
   } else {
     if (isNaN(val)) { // eslint-disable-line no-restricted-globals
       log.warn(`Coding error; stats() passed a non-numeric value for "${key}"`);
@@ -105,6 +142,12 @@ function stats(key, val_) {
       counterStats[key] = val;
     } else {
       counterStats[key] += val;
+    }
+
+    if (!(key in globalCounterStats)) {
+      globalCounterStats[key] = val;
+    } else {
+      globalCounterStats[key] += val;
     }
   }
 }

--- a/lib/validators/printer/register.schema.json
+++ b/lib/validators/printer/register.schema.json
@@ -28,16 +28,28 @@
       "$ref": "../defs.json#/definitions/mac"
     },
     "mfg": {
-      "description": "Name of the printer's manufacturer",
+      "description": "Name of the printer's manufacturer (e.g., FormLabs)",
       "type": "string",
       "minLength": 1,
-      "maxLength": 64
+      "maxLength": 32
+    },
+    "mfgModel": {
+      "description": "Name of the printer model (e.g., Form 3)",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 32
     },
     "mfgSn": {
       "description": "Printer's manufacturer serial number",
       "type": "string",
       "minLength": 1,
-      "maxLength": 64
+      "maxLength": 32
+    },
+    "mfgData": {
+      "description": "Additional printer data to save",
+      "type": "string",
+      "minLength": 0,
+      "maxLength": 1024
     }
   },
   "required": [
@@ -45,6 +57,7 @@
     "pin",
     "MAC",
     "mfg",
+    "mfgModel",
     "publicKey"
   ],
   "_validationRequired": false

--- a/lib/validators/printer/unregister.schema.json
+++ b/lib/validators/printer/unregister.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "http://apexslicer.com/schemas/cloud/unregister.json",
-  "title": "register",
+  "title": "unregister",
   "description": "Unregister a printer with the Printer Server",
   "type": "object",
   "properties": {

--- a/lib/validators/server/registerResponse.schema.json
+++ b/lib/validators/server/registerResponse.schema.json
@@ -21,9 +21,6 @@
       "type": "string",
       "enum": [
         "EMAIL_PIN_ERROR",
-        "INVALID_KEY",
-        "INVALID_MAC",
-        "INVALID_MFG",
         "SERVER_ERROR",
         "SUCCESS"
       ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mobius3d/mobius-lib",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -301,9 +301,9 @@
       "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
     "aws-sdk": {
-      "version": "2.868.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.868.0.tgz",
-      "integrity": "sha512-ZayPsA/ycaAXqqa2oDyf8iUpl1WOLODZS8ZdvYj77L5owMQm0XC7yqiD+WHj9nToUECF9VAD+AKQMIN6695tVQ==",
+      "version": "2.870.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.870.0.tgz",
+      "integrity": "sha512-pbNO+RuEx45aaEZind0Tl9NADxncLJf0mRAwof0szyYMB+FZm165yz7FCxFLumU4R9qw8vOG5YFACBaNoQkJdg==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -878,9 +878,9 @@
           "dev": true
         },
         "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -2038,9 +2038,9 @@
       }
     },
     "mongoose": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.12.1.tgz",
-      "integrity": "sha512-g/oIEvQQrK1XcICS/PfzU1Gu1s6Uw1rgJP7/SfC3Ru6pTLa1dH2Lb+iJipNWqChbrykE78j/wwBVSsbyCZRl5Q==",
+      "version": "5.12.2",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.12.2.tgz",
+      "integrity": "sha512-kT9t6Nvu9WPsfssn7Gzke446Il8UdMilY7Sa5vALtwoOoNOGtZEVjekZBFwsBFzTWtBA/x5gBmJoYFP+1LeDlg==",
       "requires": {
         "@types/mongodb": "^3.5.27",
         "bson": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mobius3d/mobius-lib",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "Common mobius libraries",
   "main": "index.js",
   "scripts": {

--- a/test/validators/printer/register.schema.test.js
+++ b/test/validators/printer/register.schema.test.js
@@ -19,6 +19,7 @@ describe(`Printer ${CMD} command validator`, () => {
     publicKey: 'Kwikset Schlage'.padEnd(72, 'x'),
     MAC: 'DE:AD:BE:EF:20:20',
     mfg: 'Acme Mfg',
+    mfgModel: 'Whizbang Pro++ 2000',
     mfgSn: '0001'
   };
 
@@ -187,6 +188,14 @@ describe(`Printer ${CMD} command validator`, () => {
   it('rejects a mfgSn which is too long', (done) => {
     const payload = deepClone(goodPayload);
     payload.mfgSn = '123'.padEnd(64, 'x');
+    const result = validators.validatePrinterCommand(CMD);
+    expect(result).to.not.be.null;
+    return done();
+  });
+
+  it('rejects a missing mfgModel which is too long', (done) => {
+    const payload = deepClone(goodPayload);
+    delete payload.mfgModel;
     const result = validators.validatePrinterCommand(CMD);
     expect(result).to.not.be.null;
     return done();


### PR DESCRIPTION
- stats package should automatically update global totals when updating hourly bins
- add `mfgModel` to registration info along with existing `mfg` and `mfgSn`
- remove no longer needed error cases from `registerResponse`
- fix a typo