### PR TITLE
Require jobId in some commands

### DIFF
--- a/lib/oid.js
+++ b/lib/oid.js
@@ -25,8 +25,8 @@ function currentHour() {
 
 function oidFromDateTime(timestamp) {
   const ts = (typeof timestamp === 'string') ? new Date(timestamp) : (timestamp ?? currentHour());
-  const hexSeconds = Math.floor(ts / 1000).toString(16);
-  return ObjectId(hexSeconds + '0000000000000000'); // eslint-disable-line prefer-template
+  const hexSeconds = Math.floor(ts / 1000).toString(16).padEnd(24, '0');
+  return ObjectId(hexSeconds);
 }
 
 function dateTimeFromOid(objectId) {
@@ -38,10 +38,14 @@ function containsOid(list, oid) {
   return list.some((id) => id.equals(oid));
 }
 
+function ensure(oid) {
+  return (typeof oid === 'string') ? ObjectId(oid) : oid;
+}
 module.exports = {
   containsOid,
   currentHour,
   dateTimeFromOid,
+  ensure,
   objectIdTimeZero,
   oidFromDateTime
 };

--- a/lib/oid.js
+++ b/lib/oid.js
@@ -41,6 +41,7 @@ function containsOid(list, oid) {
 function ensure(oid) {
   return (typeof oid === 'string') ? ObjectId(oid) : oid;
 }
+
 module.exports = {
   containsOid,
   currentHour,

--- a/lib/validators/defs.json
+++ b/lib/validators/defs.json
@@ -45,6 +45,12 @@
       "type": "string",
       "pattern": "^[\\da-fA-F]{12}$|^(([\\da-fA-F]{2}[-:]){5}[\\da-fA-F]{2})$|^([\\da-f]{4}\\\\.[\\da-f]{4}\\\\.[\\da-f]{4})$\""
     },
+    "localJobId": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 24,
+      "pattern": "^[a-fA-F0-9]{24}$|^123$"
+    },
     "mediaUploadMethods": {
       "description": "HTTP request method for media upload",
       "type": "string",

--- a/lib/validators/printer/job.schema.json
+++ b/lib/validators/printer/job.schema.json
@@ -9,10 +9,7 @@
       "$ref": "../defs.json#/definitions/mongoObjectId"
     },
     "jobId": {
-      "type": "string",
-      "minLength": 3,
-      "maxLength": 24,
-      "pattern": "^[a-fA-F0-9]{24}$|^123$"
+      "$ref": "../defs.json#/definitions/localJobId"
     },
     "state": {
       "description": "Print completion status",

--- a/lib/validators/printer/status.schema.json
+++ b/lib/validators/printer/status.schema.json
@@ -12,7 +12,7 @@
       "$ref": "../defs.json#/definitions/printerStatesEnum"
     },
     "jobId": {
-      "$ref": "../defs.json#/definitions/mongoObjectId"
+      "$ref": "../defs.json#/definitions/localJobId"
     },
     "printSeconds": {
       "type": "number",

--- a/lib/validators/server/cancel.schema.json
+++ b/lib/validators/server/cancel.schema.json
@@ -5,9 +5,11 @@
   "description": "Abort the current print on the specified printer",
   "type": "object",
   "properties": {
-    "serialNumber": { "$ref" : "../defs.json#/definitions/mongoObjectId" }
+    "serialNumber": { "$ref" : "../defs.json#/definitions/mongoObjectId" },
+    "jobId": { "$ref": "../defs.json#/definitions/localJobId" }
   },
   "required": [
-    "serialNumber"
+    "serialNumber",
+    "jobId"
   ]
 }

--- a/lib/validators/server/pause.schema.json
+++ b/lib/validators/server/pause.schema.json
@@ -5,9 +5,8 @@
   "description": "Pause the current print",
   "type": "object",
   "properties": {
-    "serialNumber": {
-      "$ref": "../defs.json#/definitions/mongoObjectId"
-    },
+    "serialNumber": { "$ref": "../defs.json#/definitions/mongoObjectId" },
+    "jobId": { "$ref": "../defs.json#/definitions/localJobId" },
     "type": {
       "description": "Type of pause",
       "type": "string",
@@ -16,6 +15,7 @@
   },
   "required": [
     "serialNumber",
+    "jobId",
     "type"
   ]
 }

--- a/lib/validators/server/resume.schema.json
+++ b/lib/validators/server/resume.schema.json
@@ -5,9 +5,11 @@
   "description": "Resume the current print on the specified printer",
   "type": "object",
   "properties": {
-    "serialNumber": { "$ref" : "../defs.json#/definitions/mongoObjectId" }
+    "serialNumber": { "$ref" : "../defs.json#/definitions/mongoObjectId" },
+    "jobId": { "$ref": "../defs.json#/definitions/localJobId" }
   },
   "required": [
-    "serialNumber"
+    "serialNumber",
+    "jobId"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mobius3d/mobius-lib",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -156,9 +156,9 @@
       }
     },
     "@types/node": {
-      "version": "14.14.35",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
-      "integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag=="
+      "version": "14.14.36",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.36.tgz",
+      "integrity": "sha512-kjivUwDJfIjngzbhooRnOLhGYz6oRFi+L+EpMjxroDYXwDw9lHrJJ43E+dJ6KAd3V3WxWAJ/qZE9XKYHhjPOFQ=="
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -301,9 +301,9 @@
       "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
     "aws-sdk": {
-      "version": "2.871.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.871.0.tgz",
-      "integrity": "sha512-rFd2shGgYfCzQQQeqqgZRiLuPFUm3uUlHqM40nMtbqM1y7abuOUyuOMxTHsKsbY+Bu7gRESngPTf7Iknxq9/uQ==",
+      "version": "2.872.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.872.0.tgz",
+      "integrity": "sha512-hI1/iwR1uPbuulvWZmCCmLKN1Oiv+Beutwcn+7ZOsWAEtsgsXiHmuRDS/ZdWiBRNQkfZgUhcCwLz7nOrWKpb8w==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -2922,15 +2922,15 @@
       "dev": true
     },
     "unbox-primitive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.0.tgz",
-      "integrity": "sha512-P/51NX+JXyxK/aigg1/ZgyccdAxm5K1+n8+tvqSntjOivPt19gvm1VC49RWYetsiub8WViUchdxl/KWHHB0kzA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.0",
-        "has-symbols": "^1.0.0",
-        "which-boxed-primitive": "^1.0.1"
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
       }
     },
     "unpipe": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mobius3d/mobius-lib",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "description": "Common mobius libraries",
   "main": "index.js",
   "scripts": {

--- a/test/oid.test.js
+++ b/test/oid.test.js
@@ -20,4 +20,31 @@ describe('OID library', () => {
     expect(dt.getTime()).to.equal(oid.dateTimeFromOid(id).getTime());
     done();
   });
+
+  it('should correctly identify that an oid is in an array of oids', (done) => {
+    const oid1 = oid.oidFromDateTime('1970/03/04');
+    const oid2 = oid.oidFromDateTime('1985/09/25');
+    const oid3 = oid.oidFromDateTime('2000/01/01');
+    const oid4 = oid.oidFromDateTime('2021/03/03');
+    const list = [oid1, oid2, oid3, oid4];
+    expect(oid.containsOid(list, oid3)).to.be.true;
+    done();
+  });
+
+  it('should correctly identify that an oid is not in an array of oids', (done) => {
+    const oid1 = oid.oidFromDateTime('1970/03/04');
+    const oid2 = oid.oidFromDateTime('1985/09/25');
+    const oid3 = oid.oidFromDateTime('2000/01/01');
+    const oid4 = oid.oidFromDateTime('2021/03/03');
+    const list = [oid1, oid2, oid4];
+    expect(oid.containsOid(list, oid3)).to.be.false;
+    done();
+  });
+
+  it('should correctly convert oids', (done) => {
+    const oid1 = oid.oidFromDateTime('1970/03/04');
+    const oid2 = oid.ensure(oid1.toHexString());
+    expect(oid1.equals(oid2)).to.be.true;
+    done();
+  });
 });

--- a/test/validators/server/cancel.schema.test.js
+++ b/test/validators/server/cancel.schema.test.js
@@ -14,10 +14,21 @@ function deepClone(obj) {
 }
 
 describe(`Cloud ${CMD} command validator`, () => {
-  const goodPayload = { serialNumber: SERIAL_NUMBER };
+  const goodPayload = {
+    serialNumber: SERIAL_NUMBER,
+    jobId: SERIAL_NUMBER
+  };
 
   it('accepts a valid payload', (done) => {
     const result = validators.validateServerCommand(CMD, goodPayload);
+    expect(result).to.be.null;
+    return done();
+  });
+
+  it('accepts a local jobId', (done) => {
+    const payload = deepClone(goodPayload);
+    payload.jobId = '123';
+    const result = validators.validateServerCommand(CMD, payload);
     expect(result).to.be.null;
     return done();
   });
@@ -37,6 +48,22 @@ describe(`Cloud ${CMD} command validator`, () => {
   it('rejects an invalid serialNumber', (done) => {
     const payload = deepClone(goodPayload);
     payload.serialNumber = '###';
+    const result = validators.validateServerCommand(CMD, payload);
+    expect(result).to.not.be.null;
+    return done();
+  });
+
+  it('rejects a missing jobId', (done) => {
+    const payload = deepClone(goodPayload);
+    delete payload.jobId;
+    const result = validators.validateServerCommand(CMD, payload);
+    expect(result).to.not.be.null;
+    return done();
+  });
+
+  it('rejects an invalid jobId', (done) => {
+    const payload = deepClone(goodPayload);
+    payload.jobId = '1';
     const result = validators.validateServerCommand(CMD, payload);
     expect(result).to.not.be.null;
     return done();

--- a/test/validators/server/pause.schema.test.js
+++ b/test/validators/server/pause.schema.test.js
@@ -16,11 +16,20 @@ function deepClone(obj) {
 describe(`Cloud ${CMD} command validator`, () => {
   const goodPayload = {
     serialNumber: SERIAL_NUMBER,
+    jobId: '12345678901234567890abcd',
     type: 'PAUSE'
   };
 
   it('accepts a valid success payload', (done) => {
     const result = validators.validateServerCommand(CMD, goodPayload);
+    expect(result).to.be.null;
+    return done();
+  });
+
+  it('accepts a local jobId', (done) => {
+    const payload = deepClone(goodPayload);
+    payload.jobId = '123';
+    const result = validators.validateServerCommand(CMD, payload);
     expect(result).to.be.null;
     return done();
   });
@@ -56,6 +65,22 @@ describe(`Cloud ${CMD} command validator`, () => {
   it('rejects an invalid type', (done) => {
     const payload = deepClone(goodPayload);
     payload.type = 'COLD';
+    const result = validators.validateServerCommand(CMD, payload);
+    expect(result).to.not.be.null;
+    return done();
+  });
+
+  it('rejects a missing jobId', (done) => {
+    const payload = deepClone(goodPayload);
+    delete payload.jobId;
+    const result = validators.validateServerCommand(CMD, payload);
+    expect(result).to.not.be.null;
+    return done();
+  });
+
+  it('rejects an invalid jobId', (done) => {
+    const payload = deepClone(goodPayload);
+    payload.jobId = '1';
     const result = validators.validateServerCommand(CMD, payload);
     expect(result).to.not.be.null;
     return done();

--- a/test/validators/server/resume.schema.test.js
+++ b/test/validators/server/resume.schema.test.js
@@ -14,10 +14,21 @@ function deepClone(obj) {
 }
 
 describe(`Cloud ${CMD} command validator`, () => {
-  const goodPayload = { serialNumber: SERIAL_NUMBER };
+  const goodPayload = {
+    serialNumber: SERIAL_NUMBER,
+    jobId: SERIAL_NUMBER
+  };
 
   it('accepts a valid payload', (done) => {
     const result = validators.validateServerCommand(CMD, goodPayload);
+    expect(result).to.be.null;
+    return done();
+  });
+
+  it('accepts a local jobId', (done) => {
+    const payload = deepClone(goodPayload);
+    payload.jobId = '123';
+    const result = validators.validateServerCommand(CMD, payload);
     expect(result).to.be.null;
     return done();
   });
@@ -37,6 +48,22 @@ describe(`Cloud ${CMD} command validator`, () => {
   it('rejects an invalid serialNumber', (done) => {
     const payload = deepClone(goodPayload);
     payload.serialNumber = '###';
+    const result = validators.validateServerCommand(CMD, payload);
+    expect(result).to.not.be.null;
+    return done();
+  });
+
+  it('rejects a missing jobId', (done) => {
+    const payload = deepClone(goodPayload);
+    delete payload.jobId;
+    const result = validators.validateServerCommand(CMD, payload);
+    expect(result).to.not.be.null;
+    return done();
+  });
+
+  it('rejects an invalid jobId', (done) => {
+    const payload = deepClone(goodPayload);
+    payload.jobId = '1';
     const result = validators.validateServerCommand(CMD, payload);
     expect(result).to.not.be.null;
     return done();


### PR DESCRIPTION
Require `jobId` in some commands from the cloud.  This will ease centralizing where stats are accumulated.  Previously, `cancel`, `pause`, and `resume` didn't carry a `jobId` as (1) it wasn't needed, and (2) may have been for a local job.  Let's now require, when the cloud sends that command, to have a `jobId` included, even if it is just `123`.  Again, this to make simpler accumulation of printing-related stats centralized in the Printer Server.

Also, add some more unit tests.